### PR TITLE
removed extra ";" in the first introduction of default.nix in the blog

### DIFF
--- a/src/content/blog/neovim-wrapper/index.md
+++ b/src/content/blog/neovim-wrapper/index.md
@@ -128,7 +128,7 @@ convention of other Nix projects, we will use 2 files:
 let
   pkgs = import <nixpkgs> {};
 in
-  pkgs.callPackage ./neovim.nix {};
+  pkgs.callPackage ./neovim.nix {}
 ```
 
 ```nix file: "neovim-1.nix"


### PR DESCRIPTION
in the blog there was the extra ";" in default.nix at first which is not needed and cuzez issues 