### PR TITLE
Use rust-analyzer from toolchain

### DIFF
--- a/src/content/blog/nix-rustup/index.md
+++ b/src/content/blog/nix-rustup/index.md
@@ -63,13 +63,14 @@ For rust-analyzer to work properly, you will need to set up the environment vari
 # shell.nix
 ```
 
-Finally, make sure you include the `rust-src` component in your rustup toolchain definition:
+Finally, make sure you include the `rust-src` and `rust-analyzer` components in your rustup toolchain definition:
 
 ```toml
 # toolchain.toml
 [toolchain]
 components = [
-  "rust-src"
+  "rust-src",
+  "rust-analyzer"
   # ...
 ]
 ```

--- a/src/content/blog/nix-rustup/shell2.nix
+++ b/src/content/blog/nix-rustup/shell2.nix
@@ -1,9 +1,6 @@
 pkgs.mkShell {
   packages = [
     toolchain
-
-    # We want the unwrapped version, "rust-analyzer" (wrapped) comes with nixpkgs' toolchain
-    pkgs.rust-analyzer-unwrapped
   ];
 
   RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";


### PR DESCRIPTION
I just stumbled upon a problem with a version mismatch between rust-analyzer stable and cargo nightly so figured this example should be modified?